### PR TITLE
Remove azureml-designer-core reference and refine input file type as CSV and Parquet

### DIFF
--- a/aml_module/README.md
+++ b/aml_module/README.md
@@ -62,7 +62,6 @@ az ml module register --spec-file=https://github.com/microsoft/anomalydetector/b
 * `Threshold`. In AnomalyOnly mode, points are detected as anomaly if its `score` is greater than threshold. In AnomalyAndMargin mode, this parameter and `sensitivity` works together to filter anomaly.
 * `Sensitivity`. This parameter is used in AnomalyAndMargin mode to determine the range of the boundaries.
 * `Append result column to output`. If this parameter is set, the input data set will be output together with the results. Otherwise, only the results will be output.
-* `Compute stats in visualization`. If this parameter is set, the stats of output dataset will be calcualted.
 
 ## Output Specification
 The output data set will contain a fraction of the following columns according to the `Detect Mode` parameter. If multiple value colums are selected, the result columns will add value column names as postfix.

--- a/aml_module/conda.yaml
+++ b/aml_module/conda.yaml
@@ -6,11 +6,10 @@ dependencies:
   - cython=0.29.2
   - numpy=1.18.1
   - pip:
-    - pandas==0.25.3
-    - pyarrow==0.16.0
-    - matplotlib==3.1.0
-    - azureml-defaults
-    - git+https://github.com/microsoft/anomalydetector.git@1.1
     - azureml-sdk==0.1.0.*
     - --index-url https://azuremlsdktestpypi.azureedge.net/dev/aml/office/134157926D8F
     - --extra-index-url https://pypi.org/simple
+    - pandas==0.25.3
+    - pyarrow==0.16.0
+    - matplotlib==3.1.0
+    - git+https://github.com/microsoft/anomalydetector.git@1.1

--- a/aml_module/conda.yaml
+++ b/aml_module/conda.yaml
@@ -7,6 +7,7 @@ dependencies:
   - numpy=1.18.1
   - pip:
     - pandas==0.25.3
+    - pyarrow==0.16.0
     - matplotlib==3.1.0
     - azureml-defaults
     - git+https://github.com/microsoft/anomalydetector.git@1.1

--- a/aml_module/conda.yaml
+++ b/aml_module/conda.yaml
@@ -11,3 +11,6 @@ dependencies:
     - matplotlib==3.1.0
     - azureml-defaults
     - git+https://github.com/microsoft/anomalydetector.git@1.1
+    - azureml-sdk==0.1.0.*
+    - --index-url https://azuremlsdktestpypi.azureedge.net/dev/aml/office/134157926D8F
+    - --extra-index-url https://pypi.org/simple

--- a/aml_module/conda.yaml
+++ b/aml_module/conda.yaml
@@ -9,5 +9,4 @@ dependencies:
     - pandas==0.25.3
     - matplotlib==3.1.0
     - azureml-defaults
-    - azureml-designer-core==0.0.31
     - git+https://github.com/microsoft/anomalydetector.git@1.1

--- a/aml_module/error_messages.py
+++ b/aml_module/error_messages.py
@@ -4,6 +4,7 @@ DuplicateSeriesTimestamp = '''The timestamp column specified has duplicated time
 InvalidValueFormat = '''The data in column "{0}" can not be parsed as float values.'''
 InvalidSeriesValue = '''The data in column "{0}" contains nan values.'''
 ValueOverflow = '''The magnitude of data in column "{0}" exceeds limitation.'''
-NotEnoughPoints = '''The dataset should contain at leaslt {0} points to run this module.'''
+NotEnoughPoints = '''The dataset should contain at least {0} points to run this module.'''
 InvalidBatchSize = '''The "batchSize" parameter should be at least {0} or 0 ''' \
                    '''that indicates to run all data in a batch.'''
+ColumnNotFoundError = '''Column with name or index "{0}" not found.'''

--- a/aml_module/invoker.py
+++ b/aml_module/invoker.py
@@ -1,14 +1,10 @@
 import argparse
+import logging
 import os
 import pathlib
-from urllib.parse import unquote
-import pandas as pd
-import numpy as np
-from azureml.studio.core.logger import module_logger as logger
-from azureml.studio.core.io.data_frame_directory import load_data_frame_from_directory, save_data_frame_to_directory
-from azureml.studio.core.utils.column_selection import ColumnSelection
-from azureml.studio.core.error import UserError
 import sr_detector
+import numpy as np
+import pandas as pd
 from error_messages import *
 from constants import *
 
@@ -62,51 +58,47 @@ def read_as_dataframe(input_path: str):
 
 def invoke(input_path, detect_mode, timestamp_column, value_column, batch_size, threshold, sensitivity,
             appendMode, compute_stats_in_visualization, output_path):
-    # column name not exist in input file ERROR
     df = read_as_dataframe(input_path)
-
-    logger.debug(f"Shape of loaded DataFrame: {df.shape}")
+    logging.info(f"Shape of loaded DataFrame: {df.shape}")
 
     if df.shape[0] < MIN_POINTS:
-        raise UserError(NotEnoughPoints.format(MIN_POINTS))
+        raise Exception(NotEnoughPoints.format(MIN_POINTS))
 
     if 0 < batch_size < MIN_POINTS:
-        raise UserError(InvalidBatchSize.format(MIN_POINTS))
+        raise Exception(InvalidBatchSize.format(MIN_POINTS))
 
-    # query_string = unquote(timestamp_column)
-    # timestamp_column_selector = ColumnSelection(query_string)
-    # timestamp = timestamp_column_selector.select_dataframe_directory(data_frame_directory).data
-    # timestamps = pd.to_datetime(timestamp.iloc[:, 0].values)
+    if timestamp_column not in list(df.columns):
+        raise Exception(ColumnNotFoundError.format(timestamp_column))
 
-    timestamps = pd.to_datetime(df[timestamp_column])
+    if value_column not in list(df.columns):
+        raise Exception(ColumnNotFoundError.format(value_column))
+
+    timestamp = pd.DataFrame(df, columns=[timestamp_column])
+    timestamps = pd.to_datetime(timestamp.iloc[:, 0].values)
 
     if np.any(np.isnat(timestamps)):
-        raise UserError(InvalidTimestamps)
+        raise Exception(InvalidTimestamps)
 
     res = is_timestamp_ascending(timestamps)
+
     if res == -1:
-        raise UserError(InvalidSeriesOrder)
+        raise Exception(InvalidSeriesOrder)
     elif res == -2:
-        raise UserError(DuplicateSeriesTimestamp)
+        raise Exception(DuplicateSeriesTimestamp)
 
-
-    # query_string = unquote(value_column)
-    # data_column_selector = ColumnSelection(query_string)
-    # data_columns = data_column_selector.select_dataframe_directory(data_frame_directory).data
-
-    data_columns = df[value_column]
+    data_columns = pd.DataFrame(df, columns=[value_column])
 
     for col in data_columns:
         try:
             float_data = data_columns[col].apply(float)
         except Exception as e:
-            raise UserError(InvalidValueFormat.format(col))
+            raise Exception(InvalidValueFormat.format(col))
 
         if not np.all(np.isfinite(float_data)):
-            raise UserError(InvalidSeriesValue.format(col))
+            raise Exception(InvalidSeriesValue.format(col))
 
         if np.any(np.less(float_data, VALUE_LOWER_BOUND)) or np.any(np.greater(float_data, VALUE_UPPER_BOUND)):
-            raise UserError(ValueOverflow.format(col))
+            raise Exception(ValueOverflow.format(col))
 
         data_columns[col] = float_data
 
@@ -116,9 +108,10 @@ def invoke(input_path, detect_mode, timestamp_column, value_column, batch_size, 
     if appendMode is True:
         result = pd.merge(df, result, left_index=True, right_index=True)
 
-    result.to_csv(f"{output_path}/output.csv")
+    if not os.path.isdir(output_path):
+        os.mkdir(output_path)
 
-    # save_data_frame_to_directory(output_path, result, compute_stats_in_visualization=compute_stats_in_visualization)
+    result.to_csv(f"{output_path}/output.csv", index=False)
 
 
 def main():
@@ -177,19 +170,19 @@ def main():
 
     args, _ = parser.parse_known_args()
 
-    logger.info(f"Hello world from {PACKAGE_NAME} {VERSION}")
+    logging.info(f"Hello world from {PACKAGE_NAME} {VERSION}")
 
-    logger.debug("Received parameters:")
-    logger.debug(f"input: {args.input_path}")
-    logger.debug(f"detect mode: {args.detect_mode}")
-    logger.debug(f"timestamp column: {args.timestamp_column}")
-    logger.debug(f"value column: {args.value_column}")
-    logger.debug(f"batch size: {args.batch_size}")
-    logger.debug(f"threshold: {args.threshold}")
-    logger.debug(f"sensitivity: {args.sensitivity}")
-    logger.debug(f"appendMode: {args.append_mode}")
-    logger.debug(f"appendMode: {args.compute_stats_in_visualization}")
-    logger.debug(f"output path: {args.output_path}")
+    logging.debug("Received parameters:")
+    logging.debug(f"input: {args.input_path}")
+    logging.debug(f"detect mode: {args.detect_mode}")
+    logging.debug(f"timestamp column: {args.timestamp_column}")
+    logging.debug(f"value column: {args.value_column}")
+    logging.debug(f"batch size: {args.batch_size}")
+    logging.debug(f"threshold: {args.threshold}")
+    logging.debug(f"sensitivity: {args.sensitivity}")
+    logging.debug(f"appendMode: {args.append_mode}")
+    logging.debug(f"appendMode: {args.compute_stats_in_visualization}")
+    logging.debug(f"output path: {args.output_path}")
 
     invoke(args.input_path, args.detect_mode, args.timestamp_column, args.value_column,
         args.batch_size, args.threshold, args.sensitivity, args.append_mode,

--- a/aml_module/invoker.py
+++ b/aml_module/invoker.py
@@ -111,7 +111,7 @@ def invoke(input_path, detect_mode, timestamp_column, value_column, batch_size, 
     if not os.path.isdir(output_path):
         os.mkdir(output_path)
 
-    result.to_csv(f"{output_path}/output.csv", index=False)
+    result.to_parquet(f"{output_path}/output.parquet", index=False)
 
 
 def main():

--- a/aml_module/invoker.py
+++ b/aml_module/invoker.py
@@ -111,7 +111,7 @@ def invoke(input_path, detect_mode, timestamp_column, value_column, batch_size, 
     if not os.path.isdir(output_path):
         os.mkdir(output_path)
 
-    result.to_parquet(f"{output_path}/output.parquet", index=False)
+    result.to_csv(f"{output_path}/output.csv", index=False)
 
 
 def main():

--- a/aml_module/invoker.py
+++ b/aml_module/invoker.py
@@ -57,7 +57,7 @@ def read_as_dataframe(input_path: str):
 
 
 def invoke(input_path, detect_mode, timestamp_column, value_column, batch_size, threshold, sensitivity,
-            appendMode, compute_stats_in_visualization, output_path):
+            appendMode, output_path):
     df = read_as_dataframe(input_path)
     logging.info(f"Shape of loaded DataFrame: {df.shape}")
 
@@ -159,11 +159,6 @@ def main():
     )
 
     parser.add_argument(
-        '--compute-stats-in-visualization', type=str2bool, default=False,
-        help='Enable this parameter to get stats visualization.'
-    )
-
-    parser.add_argument(
         '--output-path',
         help='Output path'
     )
@@ -181,12 +176,10 @@ def main():
     logging.debug(f"threshold: {args.threshold}")
     logging.debug(f"sensitivity: {args.sensitivity}")
     logging.debug(f"appendMode: {args.append_mode}")
-    logging.debug(f"appendMode: {args.compute_stats_in_visualization}")
     logging.debug(f"output path: {args.output_path}")
 
     invoke(args.input_path, args.detect_mode, args.timestamp_column, args.value_column,
-        args.batch_size, args.threshold, args.sensitivity, args.append_mode,
-        args.compute_stats_in_visualization, args.output_path)
+        args.batch_size, args.threshold, args.sensitivity, args.append_mode, args.output_path)
 
 
 if __name__ == '__main__':

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.0
+  moduleVersion: 1.0.1
   namespace: microsoft.com/office
 metadata:
   annotations:

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.10
+  moduleVersion: 1.0.0
   namespace: microsoft.com/office
 metadata:
   annotations:

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.6
+  moduleVersion: 1.0.7
   namespace: microsoft.com/office
 metadata:
   annotations:

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.7
+  moduleVersion: 1.0.8
   namespace: microsoft.com/office
 metadata:
   annotations:

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -9,19 +9,19 @@ metadata:
 description: This module implements the spectral residual anomaly detection algorithm for time-series.
 inputs:
   - name: Dataset
-    type: DataFrameDirectory
+    type: AnyDirectory
   - name: Detect Mode
     type: Enum
     default: AnomalyOnly
     description: Specify the detection mode.
     options: [AnomalyOnly, AnomalyAndMargin]
   - name: Timestamp Column
-    type: ColumnPicker
+    type: String
     description: Choose the column that contains timestamps.
     columnPickerFor: Dataset
     singleColumnSelection: true
   - name: Value Column
-    type: ColumnPicker
+    type: String
     description: Choose the column that contains values.
     columnPickerFor: Dataset
   - name: Batch Size
@@ -51,7 +51,7 @@ inputs:
     default: True
 outputs:
   - name: Output Port
-    type: DataFrameDirectory
+    type: AnyDirectory
 implementation:
   container:
     amlEnvironment:

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.5
+  moduleVersion: 1.0.6
   namespace: microsoft.com/office
 metadata:
   annotations:
@@ -45,10 +45,6 @@ inputs:
     description: Append result columns to the original columns as output
     type: Boolean
     default: True
-  - name: Compute stats in visualization
-    description: Compute stats in visualization
-    type: Boolean
-    default: True
 outputs:
   - name: Output Port
     type: AnyDirectory
@@ -67,6 +63,5 @@ implementation:
       --threshold, { inputValue: Threshold },
       --sensitivity, { inputValue: Sensitivity },
       --append-mode, { inputValue: Append result columns to output },
-      --compute-stats-in-visualization, { inputValue: Compute stats in visualization },
       --output, { outputPath: Output Port },
     ]

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.9
+  moduleVersion: 1.0.10
   namespace: microsoft.com/office
 metadata:
   annotations:

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.8
+  moduleVersion: 1.0.9
   namespace: microsoft.com/office
 metadata:
   annotations:

--- a/aml_module/module_spec.yaml
+++ b/aml_module/module_spec.yaml
@@ -1,6 +1,6 @@
 amlModuleIdentifier:
   moduleName: Spectral Residual Anomaly Detection
-  moduleVersion: 1.0.0
+  moduleVersion: 1.0.5
   namespace: microsoft.com/office
 metadata:
   annotations:

--- a/aml_module/sr_detector.py
+++ b/aml_module/sr_detector.py
@@ -2,7 +2,7 @@ import pandas as pd
 from msanomalydetector import SpectralResidual, DetectMode
 import matplotlib
 import matplotlib.pyplot as plt
-from azureml.studio.core.logger import module_logger as logger
+import logging
 from azureml.core.run import Run
 import os
 
@@ -41,7 +41,7 @@ def detect(timestamp, data_to_detect, detect_mode, batch_size, threshold=0.3, se
 
     column_length = len(data_to_detect.columns)
     if column_length == 1:
-        logger.debug('single column to detect')
+        logging.debug('single column to detect')
 
         frame = pd.DataFrame(columns=['timestamp', 'value'])
         frame['timestamp'] = timestamp
@@ -49,7 +49,7 @@ def detect(timestamp, data_to_detect, detect_mode, batch_size, threshold=0.3, se
         output = sr_detect(frame, detect_mode, batch_size, threshold, sensitivity)
         log_plot_result(frame, output, data_to_detect.columns[0], detect_mode)
     else:
-        logger.debug(f'detect {column_length} columns')
+        logging.debug(f'detect {column_length} columns')
         output = pd.DataFrame()
 
         for col in data_to_detect.columns:

--- a/aml_module/tests/test_error_input.py
+++ b/aml_module/tests/test_error_input.py
@@ -39,7 +39,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_invalid_timestamp(self):
         df = pd.DataFrame()
@@ -50,7 +50,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_invalid_series_order(self):
         df = pd.DataFrame()
@@ -62,7 +62,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_dunplicate_sereis(self):
         df = pd.DataFrame()
@@ -73,7 +73,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_invalid_value_format(self):
         df = pd.DataFrame()
@@ -85,7 +85,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_invalid_series_value(self):
         df = pd.DataFrame()
@@ -97,7 +97,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_value_overflow(self):
         df = pd.DataFrame()
@@ -109,7 +109,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_not_enough_points(self):
         df = pd.DataFrame()
@@ -121,7 +121,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_invalid_batch_size(self):
         df = pd.DataFrame()
@@ -132,8 +132,7 @@ class TestErrorInput(unittest.TestCase):
         self.assertRaisesRegexp(Exception, 'The "batchSize" parameter should be at least 12 or 0 that indicates to run all data in a batch',
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
-                                5, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                5, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
 
     def test_timestamp_column_missing(self):
         df = pd.DataFrame()
@@ -145,7 +144,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
     def test_value_column_missing(self):
         df = pd.DataFrame()
@@ -157,7 +156,7 @@ class TestErrorInput(unittest.TestCase):
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                                self.compute_stats_in_visualization, self.__output_path)
+                                self.__output_path)
 
 
 if __name__ == '__main__':

--- a/aml_module/tests/test_error_input.py
+++ b/aml_module/tests/test_error_input.py
@@ -6,38 +6,36 @@ import numpy as np
 import pandas as pd
 import shutil
 import os
-from azureml.studio.core.io.data_frame_directory import save_data_frame_to_directory
-from azureml.studio.core.error import UserError
 import invoker
 
 
 class TestErrorInput(unittest.TestCase):
     def setUp(self):
-        self.__input_path = './test_input_data_frame_directory'
+        self.__input_path = './error_test_input_file.csv'
         self.__detect_mode = 'AnomalyOnly'
-        self.__timestamp_column = '%7B%22isFilter%22%3Atrue%2C%22rules%22%3A%5B%7B%22exclude%22%3Afalse%2C%22ruleType%22%3A%22ColumnNames%22%2C%22columns%22%3A%5B%22timestamp%22%5D%7D%5D%7D'
-        self.__value_column = '%7B%22isFilter%22%3Atrue%2C%22rules%22%3A%5B%7B%22exclude%22%3Afalse%2C%22ruleType%22%3A%22ColumnNames%22%2C%22columns%22%3A%5B%22value%22%5D%7D%5D%7D'
+        self.__timestamp_column = 'timestamp'
+        self.__value_column = 'value'
         self.__batch_size = 2000
         self.__threshold = 0.3
         self.__sensitivity = 99
         self.__append_mode = True
         self.compute_stats_in_visualization = False
-        self.__output_path = './test_output_data_frame_directory'
+        self.__output_path = './error_test_output_directory'
 
     def tearDown(self):
         self.deleteDataFrameDirectory()
 
     def deleteDataFrameDirectory(self):
         if os.path.exists(self.__input_path):
-            shutil.rmtree(self.__input_path)
+            os.remove(self.__input_path)
 
         if os.path.exists(self.__output_path):
             shutil.rmtree(self.__output_path)
 
     def test_empty_input(self):
         df = pd.DataFrame()
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, "The dataset should contain at leaslt 12 points to run this module.",
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, "The dataset should contain at least 12 points to run this module.",
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -47,8 +45,8 @@ class TestErrorInput(unittest.TestCase):
         df = pd.DataFrame()
         df['timestamp'] = 'invalid'
         df['value'] = np.ones(20)
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, "The timestamp column specified is malformed.",
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, "The timestamp column specified is malformed.",
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -59,8 +57,8 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=20, freq='1D')[::-1]
         df['timestamp'] = timestamps
         df['value'] = np.ones(20)
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, "The timestamp column specified is not in ascending order.",
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, "The timestamp column specified is not in ascending order.",
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -70,8 +68,8 @@ class TestErrorInput(unittest.TestCase):
         df = pd.DataFrame()
         df['value'] = np.ones(20)
         df['timestamp'] = '2020-01-01'
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, "The timestamp column specified has duplicated timestamps.",
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, "The timestamp column specified has duplicated timestamps.",
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -82,8 +80,8 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=20, freq='1D')
         df['timestamp'] = timestamps
         df['value'] = 'invalid'
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, 'The data in column "value" can not be parsed as float values.',
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, 'The data in column "value" can not be parsed as float values.',
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -94,8 +92,8 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=20, freq='1D')
         df['timestamp'] = timestamps
         df['value'] = np.nan
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, 'The data in column "value" contains nan values.',
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, 'The data in column "value" contains nan values.',
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -106,8 +104,8 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=20, freq='1D')
         df['timestamp'] = timestamps
         df['value'] = 1e200
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, 'The magnitude of data in column "value" exceeds limitation.',
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, 'The magnitude of data in column "value" exceeds limitation.',
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -118,8 +116,8 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=10, freq='1D')
         df['timestamp'] = timestamps
         df['value'] = np.sin(np.linspace(1, 10, 10))
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, "The dataset should contain at leaslt 12 points to run this module.",
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, "The dataset should contain at least 12 points to run this module.",
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -130,8 +128,8 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=20, freq='1D')
         df['timestamp'] = timestamps
         df['value'] = np.sin(np.linspace(1, 10, 20))
-        save_data_frame_to_directory(self.__input_path, df)
-        self.assertRaisesRegexp(UserError, 'The "batchSize" parameter should be at least 12 or 0 that indicates to run all data in a batch',
+        df.to_csv(self.__input_path)
+        self.assertRaisesRegexp(Exception, 'The "batchSize" parameter should be at least 12 or 0 that indicates to run all data in a batch',
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                                 5, self.__threshold, self.__sensitivity, self.__append_mode,
@@ -142,7 +140,7 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=20, freq='1D')
         df['time'] = timestamps
         df['value'] = np.sin(np.linspace(1, 10, 20))
-        save_data_frame_to_directory(self.__input_path, df)
+        df.to_csv(self.__input_path)
         self.assertRaisesRegexp(Exception, 'Column with name or index "timestamp" not found.',
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
@@ -154,7 +152,7 @@ class TestErrorInput(unittest.TestCase):
         timestamps = pd.date_range(start='2020-01-01', periods=20, freq='1D')
         df['timestamp'] = timestamps
         df['missed'] = np.sin(np.linspace(1, 10, 20))
-        save_data_frame_to_directory(self.__input_path, df)
+        df.to_csv(self.__input_path)
         self.assertRaisesRegexp(Exception, 'Column with name or index "value" not found.',
                                 invoker.invoke,
                                 self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,

--- a/aml_module/tests/test_functionality.py
+++ b/aml_module/tests/test_functionality.py
@@ -63,7 +63,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -76,7 +76,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -90,7 +90,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -103,7 +103,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -117,7 +117,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -130,7 +130,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -144,7 +144,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -157,7 +157,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -171,7 +171,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -184,7 +184,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -198,7 +198,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -211,7 +211,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)

--- a/aml_module/tests/test_functionality.py
+++ b/aml_module/tests/test_functionality.py
@@ -63,7 +63,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -76,7 +76,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -90,7 +90,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -103,7 +103,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -117,7 +117,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -130,7 +130,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -144,7 +144,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -157,7 +157,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -171,7 +171,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -184,7 +184,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -198,7 +198,7 @@ class TestErrorInput(unittest.TestCase):
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -211,7 +211,7 @@ class TestErrorInput(unittest.TestCase):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
-        result = pd.read_parquet(f"{self.__output_path}/output.parquet")
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)

--- a/aml_module/tests/test_functionality.py
+++ b/aml_module/tests/test_functionality.py
@@ -21,7 +21,6 @@ class TestErrorInput(unittest.TestCase):
         self.__threshold = 0.3
         self.__sensitivity = 99
         self.__append_mode = True
-        self.compute_stats_in_visualization = True,
         self.__output_path = './functional_test_output_directory'
 
     def tearDown(self):
@@ -63,8 +62,7 @@ class TestErrorInput(unittest.TestCase):
         df = self.generate_input_data_frame()
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
@@ -77,8 +75,7 @@ class TestErrorInput(unittest.TestCase):
     def testAnomalyOnlyModeCsvFolder(self):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
@@ -92,8 +89,7 @@ class TestErrorInput(unittest.TestCase):
         df = self.generate_input_data_frame()
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
@@ -106,8 +102,7 @@ class TestErrorInput(unittest.TestCase):
     def testAnomalyOnlyModeParquetFolder(self):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
@@ -121,8 +116,7 @@ class TestErrorInput(unittest.TestCase):
         df = self.generate_input_data_frame()
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
@@ -135,8 +129,7 @@ class TestErrorInput(unittest.TestCase):
     def testAnomalyAndMarginCsvFolder(self):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
@@ -150,8 +143,7 @@ class TestErrorInput(unittest.TestCase):
         df = self.generate_input_data_frame()
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
@@ -164,8 +156,7 @@ class TestErrorInput(unittest.TestCase):
     def testAnomalyAndMarginParquetFolder(self):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
@@ -179,8 +170,7 @@ class TestErrorInput(unittest.TestCase):
         df = self.generate_input_data_frame()
         df.to_csv(self.__input_csv_file, index=False)
         invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        66, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
@@ -193,8 +183,7 @@ class TestErrorInput(unittest.TestCase):
     def testBatchModeCsvFolder(self):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        66, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)
@@ -208,8 +197,7 @@ class TestErrorInput(unittest.TestCase):
         df = self.generate_input_data_frame()
         df.to_parquet(self.__input_parquet_file, index=False)
         invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        66, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
@@ -222,8 +210,7 @@ class TestErrorInput(unittest.TestCase):
     def testBatchModeParquetFolder(self):
         self.generate_input_folder('parquet')
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
-                        66, self.__threshold, self.__sensitivity, self.__append_mode,
-                        self.compute_stats_in_visualization, self.__output_path)
+                        66, self.__threshold, self.__sensitivity, self.__append_mode, self.__output_path)
         result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 600)
         self.assertTrue('value' in result.columns)

--- a/aml_module/tests/test_functionality.py
+++ b/aml_module/tests/test_functionality.py
@@ -12,10 +12,11 @@ import invoker
 
 class TestErrorInput(unittest.TestCase):
     def setUp(self):
-        self.__input_path = './functional_test_input_data_frame_directory'
+        self.__input_path = './functional_test_input_folder'
+        self.__input_file = './functional_test_input_file.csv'
         self.__detect_mode = 'AnomalyOnly'
-        self.__timestamp_column = '%7B%22isFilter%22%3Atrue%2C%22rules%22%3A%5B%7B%22exclude%22%3Afalse%2C%22ruleType%22%3A%22ColumnNames%22%2C%22columns%22%3A%5B%22timestamp%22%5D%7D%5D%7D'
-        self.__value_column = '%7B%22isFilter%22%3Atrue%2C%22rules%22%3A%5B%7B%22exclude%22%3Afalse%2C%22ruleType%22%3A%22ColumnNames%22%2C%22columns%22%3A%5B%22value%22%5D%7D%5D%7D'
+        self.__timestamp_column = 'timestamp'
+        self.__value_column = 'value'
         self.__batch_size = 2000
         self.__threshold = 0.3
         self.__sensitivity = 99
@@ -33,11 +34,35 @@ class TestErrorInput(unittest.TestCase):
         if os.path.exists(self.__output_path):
             shutil.rmtree(self.__output_path)
 
-    def testAnomalyOnlyMode(self):
+    def generate_input_data_frame(self, start_date: str = '2020-01-01'):
         df = pd.DataFrame()
-        df['timestamp'] = pd.date_range(start='2020-01-01', periods=200, freq='1D')
+        df['timestamp'] = pd.date_range(start=start_date, periods=200, freq='1D')
         df['value'] = np.sin(np.linspace(1, 20, 200))
-        save_data_frame_to_directory(self.__input_path, df)
+        return df
+
+    def generate_input_folder(self):
+        start_dates = ['2018-01-01', '2019-01-01', '2020-01-01']
+        for start_date in start_dates:
+            df = self.generate_input_data_frame(start_date)
+            df.to_csv(".".join(["/".join([self.__input_path, start_date]), 'csv']))
+
+    def testAnomalyOnlyModeCSVFile(self):
+        df = self.generate_input_data_frame()
+        df.to_csv(self.__input_file, index=False)
+        invoker.invoke(self.__input_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = load_data_frame_from_directory(self.__output_path).data
+        self.assertEqual(result.shape[0], 200)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' not in result.columns)
+        self.assertTrue('upperBoundary' not in result.columns)
+        self.assertTrue('lowerBoundary' not in result.columns)
+
+    def testAnomalyOnlyModeCSVFolder(self):
+        self.generate_input_folder()
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
                         self.compute_stats_in_visualization, self.__output_path)

--- a/aml_module/tests/test_functionality.py
+++ b/aml_module/tests/test_functionality.py
@@ -6,14 +6,14 @@ import numpy as np
 import pandas as pd
 import shutil
 import os
-from azureml.studio.core.io.data_frame_directory import load_data_frame_from_directory, save_data_frame_to_directory
 import invoker
 
 
 class TestErrorInput(unittest.TestCase):
     def setUp(self):
         self.__input_path = './functional_test_input_folder'
-        self.__input_file = './functional_test_input_file.csv'
+        self.__input_csv_file = './functional_test_input_file.csv'
+        self.__input_parquet_file = './functional_test_input_file.parquet'
         self.__detect_mode = 'AnomalyOnly'
         self.__timestamp_column = 'timestamp'
         self.__value_column = 'value'
@@ -22,7 +22,7 @@ class TestErrorInput(unittest.TestCase):
         self.__sensitivity = 99
         self.__append_mode = True
         self.compute_stats_in_visualization = True,
-        self.__output_path = './functional_test_output_data_frame_directory'
+        self.__output_path = './functional_test_output_directory'
 
     def tearDown(self):
         self.deleteDataFrameDirectory()
@@ -30,6 +30,12 @@ class TestErrorInput(unittest.TestCase):
     def deleteDataFrameDirectory(self):
         if os.path.exists(self.__input_path):
             shutil.rmtree(self.__input_path)
+
+        if os.path.exists(self.__input_csv_file):
+            os.remove(self.__input_csv_file)
+
+        if os.path.exists(self.__input_parquet_file):
+            os.remove(self.__input_parquet_file)
 
         if os.path.exists(self.__output_path):
             shutil.rmtree(self.__output_path)
@@ -40,19 +46,26 @@ class TestErrorInput(unittest.TestCase):
         df['value'] = np.sin(np.linspace(1, 20, 200))
         return df
 
-    def generate_input_folder(self):
+    def generate_input_folder(self, file_type: str = 'csv'):
+        if not os.path.isdir(self.__input_path):
+            os.mkdir(self.__input_path)
         start_dates = ['2018-01-01', '2019-01-01', '2020-01-01']
         for start_date in start_dates:
             df = self.generate_input_data_frame(start_date)
-            df.to_csv(".".join(["/".join([self.__input_path, start_date]), 'csv']))
+            if file_type == 'csv':
+                df.to_csv(f"{self.__input_path}/{start_date}.csv", index=False)
+            elif file_type == 'parquet':
+                df.to_parquet(f"{self.__input_path}/{start_date}.parquet", index=False)
+            else:
+                raise Exception(f'Unsupported input data type {file_type}, only csv and parquet file are allowed')
 
-    def testAnomalyOnlyModeCSVFile(self):
+    def testAnomalyOnlyModeCsvFile(self):
         df = self.generate_input_data_frame()
-        df.to_csv(self.__input_file, index=False)
-        invoker.invoke(self.__input_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
+        df.to_csv(self.__input_csv_file, index=False)
+        invoker.invoke(self.__input_csv_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
                         self.compute_stats_in_visualization, self.__output_path)
-        result = load_data_frame_from_directory(self.__output_path).data
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -61,12 +74,27 @@ class TestErrorInput(unittest.TestCase):
         self.assertTrue('upperBoundary' not in result.columns)
         self.assertTrue('lowerBoundary' not in result.columns)
 
-    def testAnomalyOnlyModeCSVFolder(self):
+    def testAnomalyOnlyModeCsvFolder(self):
         self.generate_input_folder()
         invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
                         self.compute_stats_in_visualization, self.__output_path)
-        result = load_data_frame_from_directory(self.__output_path).data
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 600)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' not in result.columns)
+        self.assertTrue('upperBoundary' not in result.columns)
+        self.assertTrue('lowerBoundary' not in result.columns)
+
+    def testAnomalyOnlyModeParquetFile(self):
+        df = self.generate_input_data_frame()
+        df.to_parquet(self.__input_parquet_file, index=False)
+        invoker.invoke(self.__input_parquet_file, self.__detect_mode, self.__timestamp_column, self.__value_column,
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -75,15 +103,56 @@ class TestErrorInput(unittest.TestCase):
         self.assertTrue('upperBoundary' not in result.columns)
         self.assertTrue('lowerBoundary' not in result.columns)
 
-    def testAnomalyAndMargin(self):
-        df = pd.DataFrame()
-        df['timestamp'] = pd.date_range(start='2020-01-01', periods=200, freq='1D')
-        df['value'] = np.sin(np.linspace(1, 20, 200))
-        save_data_frame_to_directory(self.__input_path, df)
+    def testAnomalyOnlyModeParquetFolder(self):
+        self.generate_input_folder('parquet')
+        invoker.invoke(self.__input_path, self.__detect_mode, self.__timestamp_column, self.__value_column,
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 600)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' not in result.columns)
+        self.assertTrue('upperBoundary' not in result.columns)
+        self.assertTrue('lowerBoundary' not in result.columns)
+
+    def testAnomalyAndMarginCsvFile(self):
+        df = self.generate_input_data_frame()
+        df.to_csv(self.__input_csv_file, index=False)
+        invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 200)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' in result.columns)
+        self.assertTrue('upperBoundary' in result.columns)
+        self.assertTrue('lowerBoundary' in result.columns)
+
+    def testAnomalyAndMarginCsvFolder(self):
+        self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
                         self.compute_stats_in_visualization, self.__output_path)
-        result = load_data_frame_from_directory(self.__output_path).data
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 600)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' in result.columns)
+        self.assertTrue('upperBoundary' in result.columns)
+        self.assertTrue('lowerBoundary' in result.columns)
+
+    def testAnomalyAndMarginParquetFile(self):
+        df = self.generate_input_data_frame()
+        df.to_parquet(self.__input_parquet_file, index=False)
+        invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -92,16 +161,56 @@ class TestErrorInput(unittest.TestCase):
         self.assertTrue('upperBoundary' in result.columns)
         self.assertTrue('lowerBoundary' in result.columns)
 
-    def testBatchMode(self):
-        df = pd.DataFrame()
-        df['timestamp'] = pd.date_range(start='2020-01-01', periods=200, freq='1D')
-        df['value'] = np.sin(np.linspace(1, 20, 200))
-        save_data_frame_to_directory(self.__input_path, df)
+    def testAnomalyAndMarginParquetFolder(self):
+        self.generate_input_folder('parquet')
+        invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
+                        self.__batch_size, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 600)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' in result.columns)
+        self.assertTrue('upperBoundary' in result.columns)
+        self.assertTrue('lowerBoundary' in result.columns)
+
+    def testBatchModeCsvFile(self):
+        df = self.generate_input_data_frame()
+        df.to_csv(self.__input_csv_file, index=False)
+        invoker.invoke(self.__input_csv_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
+                        66, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 200)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' in result.columns)
+        self.assertTrue('upperBoundary' in result.columns)
+        self.assertTrue('lowerBoundary' in result.columns)
+
+    def testBatchModeCsvFolder(self):
+        self.generate_input_folder()
         invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
                         66, self.__threshold, self.__sensitivity, self.__append_mode,
                         self.compute_stats_in_visualization, self.__output_path)
-        result = load_data_frame_from_directory(self.__output_path).data
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 600)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' in result.columns)
+        self.assertTrue('upperBoundary' in result.columns)
+        self.assertTrue('lowerBoundary' in result.columns)
 
+    def testBatchModeParquetFile(self):
+        df = self.generate_input_data_frame()
+        df.to_parquet(self.__input_parquet_file, index=False)
+        invoker.invoke(self.__input_parquet_file, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
+                        66, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
         self.assertEqual(result.shape[0], 200)
         self.assertTrue('value' in result.columns)
         self.assertTrue('isAnomaly' in result.columns)
@@ -110,6 +219,19 @@ class TestErrorInput(unittest.TestCase):
         self.assertTrue('upperBoundary' in result.columns)
         self.assertTrue('lowerBoundary' in result.columns)
 
+    def testBatchModeParquetFolder(self):
+        self.generate_input_folder('parquet')
+        invoker.invoke(self.__input_path, "AnomalyAndMargin", self.__timestamp_column, self.__value_column,
+                        66, self.__threshold, self.__sensitivity, self.__append_mode,
+                        self.compute_stats_in_visualization, self.__output_path)
+        result = pd.read_csv(f"{self.__output_path}/output.csv")
+        self.assertEqual(result.shape[0], 600)
+        self.assertTrue('value' in result.columns)
+        self.assertTrue('isAnomaly' in result.columns)
+        self.assertTrue('score' in result.columns)
+        self.assertTrue('expectedValue' in result.columns)
+        self.assertTrue('upperBoundary' in result.columns)
+        self.assertTrue('lowerBoundary' in result.columns)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
@guinao @conhua @weedqian @thy09 

This PR makes following changes to anomaly detector custom module：
- remove `azureml-designer-core` reference
- change `DataFrameDirectory `to `AnyDirectory`, change `ColumnPicker `to `String`
- enable input data type to be csv file, parquet file, or path that contains multiple csv files or parquet files
- remove `compute_stats_in_visualization` parameter since it is defined in `azureml-designer-core`
- use the latest version of azureml-sdk and azureml-dataprep to enable module output